### PR TITLE
Added window naming based on IP

### DIFF
--- a/local/listen.sh
+++ b/local/listen.sh
@@ -7,8 +7,9 @@ SOCKF="${SOCKDIR}/usock"
 # tmux new -s GOSH
 tmux has-session -t GOSH || tmux new-session -d -s GOSH
 
+IP=$(lsof -Pni | grep "socat.*$PORT" | tail -n 1 | sed 's/>/ /g' | awk '{ print $10 }')
 # Create window
-tmux new-window "socat UNIX-LISTEN:${SOCKF},umask=0077 STDIO"
+tmux new-window -n "$IP" "socat UNIX-LISTEN:${SOCKF},umask=0077 STDIO"
 
 # Wait for socket
 while test ! -e ${SOCKF} ; do sleep 1 ; done


### PR DESCRIPTION
I noticed that window names are usually named "socat" if not manually renamed, so I made up a slightly dirty hack to name them based on last connection from socat. 

I don't claim for this to be full proof, but it has worked pretty well for me so far.

I won't be offended if you don't merge :laughing: 

Hopefully, you find this useful!